### PR TITLE
Bugfix: modify message response object as API spec

### DIFF
--- a/lib/PlusFriendMessage.js
+++ b/lib/PlusFriendMessage.js
@@ -47,7 +47,7 @@ class PlusFriendMessage extends PlusFriendObject {
     if (!message) {
       throw new TypeError();
     }
-    return message;
+    return { message };
   }
 }
 


### PR DESCRIPTION
Before:
```
return {
  text: 'message text'
}
```

After:
```
return {
  message: {
    text: 'message text'
  }
}
```

Regarding API spec document:
```
{
  "message": {
    "text": "귀하의 차량이 성공적으로 등록되었습니다. 축하합니다!"
  }
}
```